### PR TITLE
[QAT-775] Book List & Details

### DIFF
--- a/features/books_list.feature
+++ b/features/books_list.feature
@@ -1,0 +1,12 @@
+Feature: Books List
+
+  As an automation developer
+  I want to check the books list and details
+  To check that a book is loaded correctly and with consistent information when added to the list
+
+  Scenario: Access to books list
+    Given I am on the login page
+    When I fill the required fields of the login form
+    And I click on the login button
+    Then I will "redirect to" the "books" page
+    And I can check the books attributes

--- a/features/books_list.feature
+++ b/features/books_list.feature
@@ -1,12 +1,35 @@
+@logged
 Feature: Books List
 
   As an automation developer
   I want to check the books list and details
   To check that a book is loaded correctly and with consistent information when added to the list
 
-  Scenario: Access to books list
+  Background: I am logged in
     Given I am on the login page
-    When I fill the required fields of the login form
+    And I fill the required fields of the login form
     And I click on the login button
-    Then I will "redirect to" the "books" page
-    And I can check the books attributes
+    And I will "redirect to" the "books" page
+
+  Scenario: Access to books list
+    Given I have access to the book list
+    When All the books are displayed
+    Then I can check all the books have a "title" attribute
+    And I can check all the books have a "author" attribute
+    And I can check all the books have a "image" attribute
+
+  Scenario: Access to book details
+    Given I have access to the book list
+    When All the books are displayed
+    And I click on any of the cards
+    Then I will be redirected to the book details
+    And I can check the book attributes
+
+  Scenario: Navigate suggestions bar
+    Given I have access to the book list
+    When All the books are displayed
+    And I click on any of the cards
+    Then I will be redirected to the book details
+    And I can check the suggestions bar shows four results
+    And I can navigate "right" when i press the "next" button
+    And I can navigate "left" when i press the "prev" button

--- a/features/step_definitions/books.rb
+++ b/features/step_definitions/books.rb
@@ -1,0 +1,11 @@
+Then('I can check the books attributes') do
+  wait(5)
+  wait_for_element_to_be_ready(:id, 'book_list')
+  book_list = $driver.find_elements(:id, 'book_item')
+  book_list.each do |book_item|
+    book = prepare_book(book_item)
+    expect(is_element_displayed(:id, book['title'].attribute(:id))).to be(true)
+    expect(is_element_displayed(:id, book['author'].attribute(:id))).to be(true)
+    expect(is_element_displayed(:id, book['image'].attribute(:id))).to be(true)
+  end
+end

--- a/features/step_definitions/books.rb
+++ b/features/step_definitions/books.rb
@@ -1,6 +1,5 @@
 Given('I have access to the book list') do
-  wait_for_element_to_be_ready(:id, 'book_list')
-  wait(1)
+  wait_for_element_to_be_ready(:xpath, '//*[@id="book_item"]')
 end
 
 When('All the books are displayed') do
@@ -37,7 +36,7 @@ When('I click on any of the cards') do
 end
 
 Then('I will be redirected to the book details') do
-  author = get_element_text(:id, 'deatil_author').slice(17..)
+  author = get_element_text(:id, 'deatil_author').sub('Autor del libro: ', '')
   title = get_element_text(:id, 'book_tiitle').split(' (').first
   expect(check_element_presence(:id, 'detail', true)).to be(true)
   expect(title).to eq(@clicked_book_title)
@@ -52,14 +51,14 @@ And('I can check the book attributes') do
   expect(check_element_presence(:class, 'genre', true)).to be(true)
 end
 
-Then('I can check the suggestions bar shows four results') do
+And('I can check the suggestions bar shows four results') do
   wait_for_element_to_be_ready(:class, 'carousel-inner')
   @book_slides = $driver.find_elements(:id, 'slide')
   @book_slides_activos = process_slides(@book_slides)
   expect(@book_slides_activos.length).to eq(4)
 end
 
-Then('I can navigate {string} when i press the {string} button') do |_dir, direction|
+And('I can navigate {string} when i press the {string} button') do |_dir, direction|
   wait_for_element_to_be_ready(:class, "carousel-control-#{direction}")
   click(:class, "carousel-control-#{direction}")
   book_slides_previos = @book_slides_activos

--- a/features/step_definitions/books.rb
+++ b/features/step_definitions/books.rb
@@ -1,11 +1,68 @@
-Then('I can check the books attributes') do
-  wait(5)
+Given('I have access to the book list') do
   wait_for_element_to_be_ready(:id, 'book_list')
-  book_list = $driver.find_elements(:id, 'book_item')
-  book_list.each do |book_item|
+  wait(1)
+end
+
+When('All the books are displayed') do
+  @book_list = $driver.find_elements(:id, 'book_item')
+  @book_list.each do |book_item|
     book = prepare_book(book_item)
-    expect(is_element_displayed(:id, book['title'].attribute(:id))).to be(true)
-    expect(is_element_displayed(:id, book['author'].attribute(:id))).to be(true)
-    expect(is_element_displayed(:id, book['image'].attribute(:id))).to be(true)
+    wait_for_element_to_be_ready(:id, book['title'].attribute(:id))
+    wait_for_element_to_be_ready(:id, book['author'].attribute(:id))
+    wait_for_element_to_be_ready(:id, book['image'].attribute(:id))
   end
+end
+
+Then('I can check all the books have a {string} attribute') do |attribute|
+  @book_list.each do |book_item|
+    book = prepare_book(book_item)
+    book_attribute_id = book[attribute].attribute(:id)
+    expect(check_element_presence(:id, book_attribute_id, true)).to be(true)
+    if attribute == 'image'
+      book_image_src = book['image'].attribute(:src)
+      expect(book_image_src).not_to be_empty
+      expect(book_image_src.split('.').last).to eq('jpg').or eq('jpeg')
+    else
+      expect(book[attribute].text).not_to be_empty
+    end
+  end
+end
+
+When('I click on any of the cards') do
+  clicked_book = @book_list.first
+  book = prepare_book(clicked_book)
+  @clicked_book_title = book['title'].text
+  @clicked_book_author = book['author'].text
+  click(:id, clicked_book.attribute(:id))
+end
+
+Then('I will be redirected to the book details') do
+  author = get_element_text(:id, 'deatil_author').slice(17..)
+  title = get_element_text(:id, 'book_tiitle').split(' (').first
+  expect(check_element_presence(:id, 'detail', true)).to be(true)
+  expect(title).to eq(@clicked_book_title)
+  expect(author).to eq(@clicked_book_author)
+end
+
+And('I can check the book attributes') do
+  details_ids = %w[book_tiitle deatil_author detail_publisher detail_year]
+  details_ids.each do |detail_id|
+    expect(check_element_presence(:id, detail_id, true)).to be(true)
+  end
+  expect(check_element_presence(:class, 'genre', true)).to be(true)
+end
+
+Then('I can check the suggestions bar shows four results') do
+  wait_for_element_to_be_ready(:class, 'carousel-inner')
+  @book_slides = $driver.find_elements(:id, 'slide')
+  @book_slides_activos = process_slides(@book_slides)
+  expect(@book_slides_activos.length).to eq(4)
+end
+
+Then('I can navigate {string} when i press the {string} button') do |_dir, direction|
+  wait_for_element_to_be_ready(:class, "carousel-control-#{direction}")
+  click(:class, "carousel-control-#{direction}")
+  book_slides_previos = @book_slides_activos
+  @book_slides_activos = process_slides(@book_slides)
+  expect(@book_slides_activos).not_to match_array(book_slides_previos)
 end

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -4,6 +4,6 @@ end
 
 Then('I will {string} the {string} page') do |action, page|
   expected_element = get_expected_element(action, page)
-  wait_for_element_to_display(:id, expected_element, 2)
+  wait_for_element_to_display(:id, expected_element, 3)
   expect($driver.current_url).to eq(ENV['URL'] + "/#{page}")
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,4 +1,4 @@
-Before('@login') do
+Before('@login or @logged') do
   click(:id, 'loggout') if $driver.current_url == (ENV['URL'] + '/books')
 end
 

--- a/services/helper.rb
+++ b/services/helper.rb
@@ -41,3 +41,17 @@ def find_image(book_card_container)
   image_container = book_card_container.find_element(:id, 'book_card_image_container')
   image_container.find_element(:id, 'book_card_image')
 end
+
+def process_slide_element(slide_element)
+  slide_element.attribute('aria-hidden')
+end
+
+def process_slides(slides)
+  slides_activos = []
+  contador = 0
+  slides.each do |slide|
+    contador += 1
+    slides_activos.push(contador) unless process_slide_element(slide) == 'true'
+  end
+  slides_activos
+end

--- a/services/helper.rb
+++ b/services/helper.rb
@@ -23,3 +23,21 @@ def remain_expected_element(page)
   return 'register_form' if page == 'sign-up'
   return 'login_form' if page == 'login'
 end
+
+def prepare_book(book_item)
+  book = {}
+  book_card_container = book_item.find_element(:id, 'book_card_container')
+  %w[title author image].each do |element|
+    book[element] = if element == 'image'
+                      find_image(book_card_container)
+                    else
+                      book_card_container.find_element(:class, element)
+                    end
+  end
+  book
+end
+
+def find_image(book_card_container)
+  image_container = book_card_container.find_element(:id, 'book_card_image_container')
+  image_container.find_element(:id, 'book_card_image')
+end


### PR DESCRIPTION
## Summary
- Added `books_list.feature` file to describe listing scenarios for wBooks API
    - Background:
        - added a backgroud so the user is logged in every scenario
    - Scenarios:
        - Accessing the books list
        - Access a book card to check its details
        - Access a book card to check the suggestions bar

## Jira Card
https://wolox-support.atlassian.net/browse/QAT-775?atlOrigin=eyJpIjoiYTc4MzVjMTYyNjJkNDU5ZjgxMGYwZDM2MjVjMWU2MjYiLCJwIjoiaiJ9