### PR TITLE
[QAT-774] Filters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,19 @@
 Style/Documentation:
-   Enabled: false
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
-   Enabled: false
+  Enabled: false
 
 Layout/LineLength:
-   Max: 99
+  Max: 99
+
+AllCops:
+  Exclude:
+    - "features/support/env.rb"
+
+GlobalVars:
+  AllowedVariables:
+    - $driver
+
+Metrics/LineLength:
+  Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,3 @@ AllCops:
 GlobalVars:
   AllowedVariables:
     - $driver
-
-Metrics/LineLength:
-  Max: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
 #   - bundle exec rake db:migrate
 
 script:
-  - bundle exec rspec spec -fd
   - bundle exec rubocop features --format simple
+  - bundle exec cucumber
 
 #notifications:
 #  email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 script:
   - bundle exec rspec spec -fd
-  - bundle exec rubocop app spec -P --format simple
+  - bundle exec rubocop features --format simple
 
 #notifications:
 #  email:

--- a/features/books_list.feature
+++ b/features/books_list.feature
@@ -5,12 +5,6 @@ Feature: Books List
   I want to check the books list and details
   To check that a book is loaded correctly and with consistent information when added to the list
 
-  Background: I am logged in
-    Given I am on the login page
-    And I fill the required fields of the login form
-    And I click on the login button
-    And I will "redirect to" the "books" page
-
   Scenario: Access to books list
     Given I have access to the book list
     When All the books are displayed

--- a/features/date_filter.feature
+++ b/features/date_filter.feature
@@ -1,0 +1,13 @@
+@logged @current
+Feature: Date Filter
+
+  As an automation developer
+  I want to create automation test for the search filters
+  So that testing time is reduced
+
+  Scenario: Applying 'from' and 'until'
+    Given I have access to the book list
+    And The list has no filters
+    When I fill the from_date filter
+    And I fill the until_date filter
+    Then The book list will be updated

--- a/features/date_filter.feature
+++ b/features/date_filter.feature
@@ -1,13 +1,35 @@
-@logged @current
+@logged
 Feature: Date Filter
 
   As an automation developer
   I want to create automation test for the search filters
   So that testing time is reduced
 
-  Scenario: Applying 'from' and 'until'
+  Scenario: Applying 'from' and 'until' filters
     Given I have access to the book list
     And The list has no filters
-    When I fill the from_date filter
-    And I fill the until_date filter
+    When I fill the "from_date" filter
+    And I fill the "until_date" filter
     Then The book list will be updated
+
+  Scenario: Applying only 'from' filter
+    Given I have access to the book list
+    And The list has no filters
+    When I fill the "from_date" filter
+    Then The book list will be updated
+    And There won't be books with publication date previous to the filter date
+
+  Scenario: Applying 'from' filter with the latest publication date possible
+    Given I have access to the book list
+    And The list has no filters
+    When I fill the from_date with the latest publication date possible
+    Then The book list will be updated
+    And The book list will be empty
+
+  Scenario: Removing filters
+    Given I have access to the book list
+    And The list has no filters
+    And I apply filters
+    When I click the cross button
+    Then The filters will be removed
+    And The book list will be complete

--- a/features/step_definitions/books.rb
+++ b/features/step_definitions/books.rb
@@ -1,4 +1,5 @@
 Given('I have access to the book list') do
+  wait(1)
   wait_for_element_to_be_ready(:xpath, '//*[@id="book_item"]')
 end
 

--- a/features/step_definitions/books.rb
+++ b/features/step_definitions/books.rb
@@ -1,6 +1,5 @@
 Given('I have access to the book list') do
-  wait(1)
-  wait_for_element_to_be_ready(:xpath, '//*[@id="book_item"]')
+  wait_for_element_to_display(:xpath, '//*[@id="book_item"]', 2)
 end
 
 When('All the books are displayed') do

--- a/features/step_definitions/date_filters.rb
+++ b/features/step_definitions/date_filters.rb
@@ -1,24 +1,58 @@
 And('The list has no filters') do
-  book_list = $driver.find_elements(:id, 'book_item')
-  puts book_list
-  original_book_list_count = get_books_names(book_list)
-  puts original_book_list_count
+  @original_amount_of_books = total_amount_of_books
 end
 
-When('I fill the from_date filter') do
-  from_xpath = '//*[@id="search_picker"]/div/div/input'
-  wait_for_element_to_be_ready(:xpath, from_xpath)
-  click(:xpath, from_xpath)
-  enter_text(:xpath, '01-01-2014', from_xpath)
-end
-
-And('I fill the until_date filter') do
-  until_xpath = '//*[@id="date_picker"]/div/div/input'
-  wait_for_element_to_be_ready(:xpath, until_xpath)
-  click(:xpath, until_xpath)
-  enter_text(:xpath, '12-31-2014', until_xpath)
+When('I fill the {string} filter') do |date_filter|
+  filter = process_filter(date_filter)
+  wait_for_element_to_be_ready(:xpath, filter[:xpath])
+  check_element_text(:xpath, '', filter[:xpath], true)
+  click(:xpath, filter[:xpath])
+  enter_text(:xpath, filter[:date], filter[:xpath])
 end
 
 Then('The book list will be updated') do
-  pending # Write code here that turns the phrase above into concrete actions
+  @filtered_amount_of_books = total_amount_of_books
+  expect(@filtered_amount_of_books).not_to eq(@original_amount_of_books)
+end
+
+And("There won't be books with publication date previous to the filter date") do
+  expect(@filtered_amount_of_books).to eq(15)
+end
+
+When('I fill the from_date with the latest publication date possible') do
+  calendar_button_xpath = '//*[@id="search_picker"]/div/div/div/button'
+  today_button_xpath = '//*[@id="search_picker"]/div/div[2]/table[1]/tr/td[2]/button'
+  wait_for_element_to_be_ready(:xpath, calendar_button_xpath)
+  click(:xpath, calendar_button_xpath)
+  wait_for_element_to_be_ready(:xpath, today_button_xpath)
+  click(:xpath, today_button_xpath)
+end
+
+And('The book list will be empty') do
+  expect(@filtered_amount_of_books).to eq(0)
+end
+
+And('I apply filters') do
+  apply_filters
+end
+
+When('I click the cross button') do
+  from_filter_x_button_xpath = '//*[@id="search_picker"]/div/div/div/button[1]'
+  until_filter_x_button_xpath = '//*[@id="date_picker"]/div/div/div/button[1]'
+  wait_for_element_to_be_ready(:xpath, from_filter_x_button_xpath)
+  click(:xpath, from_filter_x_button_xpath)
+  wait_for_element_to_be_ready(:xpath, until_filter_x_button_xpath)
+  click(:xpath, until_filter_x_button_xpath)
+end
+
+Then('The filters will be removed') do
+  from_filter_xpath = '//*[@id="search_picker"]/div/div/input'
+  until_filter_xpath = '//*[@id="date_picker"]/div/div/input'
+  expect(get_element_text(:xpath, from_filter_xpath)).to be_empty
+  expect(get_element_text(:xpath, until_filter_xpath)).to be_empty
+end
+
+And('The book list will be complete') do
+  @current_amount_of_books = total_amount_of_books
+  expect(@current_amount_of_books).to eq(@original_amount_of_books)
 end

--- a/features/step_definitions/date_filters.rb
+++ b/features/step_definitions/date_filters.rb
@@ -20,12 +20,9 @@ And("There won't be books with publication date previous to the filter date") do
 end
 
 When('I fill the from_date with the latest publication date possible') do
-  calendar_button_xpath = '//*[@id="search_picker"]/div/div/div/button'
-  today_button_xpath = '//*[@id="search_picker"]/div/div[2]/table[1]/tr/td[2]/button'
-  wait_for_element_to_be_ready(:xpath, calendar_button_xpath)
-  click(:xpath, calendar_button_xpath)
-  wait_for_element_to_be_ready(:xpath, today_button_xpath)
-  click(:xpath, today_button_xpath)
+  from_date_filter_xpath = '//*[@id="search_picker"]/div/div/input'
+  wait_for_element_to_be_ready(:xpath, from_date_filter_xpath)
+  enter_text(:xpath, Time.now.strftime('%m-%d-%Y'), from_date_filter_xpath)
 end
 
 And('The book list will be empty') do

--- a/features/step_definitions/date_filters.rb
+++ b/features/step_definitions/date_filters.rb
@@ -1,0 +1,24 @@
+And('The list has no filters') do
+  book_list = $driver.find_elements(:id, 'book_item')
+  puts book_list
+  original_book_list_count = get_books_names(book_list)
+  puts original_book_list_count
+end
+
+When('I fill the from_date filter') do
+  from_xpath = '//*[@id="search_picker"]/div/div/input'
+  wait_for_element_to_be_ready(:xpath, from_xpath)
+  click(:xpath, from_xpath)
+  enter_text(:xpath, '01-01-2014', from_xpath)
+end
+
+And('I fill the until_date filter') do
+  until_xpath = '//*[@id="date_picker"]/div/div/input'
+  wait_for_element_to_be_ready(:xpath, until_xpath)
+  click(:xpath, until_xpath)
+  enter_text(:xpath, '12-31-2014', until_xpath)
+end
+
+Then('The book list will be updated') do
+  pending # Write code here that turns the phrase above into concrete actions
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,6 +2,15 @@ Before('@login or @logged') do
   click(:id, 'loggout') if $driver.current_url == (ENV['URL'] + '/books')
 end
 
+Before('@logged') do
+  navigate_to(ENV['URL'])
+  wait_for_form_fields(:id, %w[email password])
+  enter_text(:id, ENV['EXISTING_EMAIL'], 'email')
+  enter_text(:id, ENV['EXISTING_PASSWORD'], 'password')
+  wait_for_element_to_display(:id, 'login', 1)
+  click(:id, 'login')
+end
+
 After do
   $driver.manage.delete_all_cookies
   $driver.local_storage.clear

--- a/services/helper.rb
+++ b/services/helper.rb
@@ -55,3 +55,14 @@ def process_slides(slides)
   end
   slides_activos
 end
+
+def get_books_names(book_elements_list)
+  array_of_names = []
+  book_elements_list.each do |book_element|
+    container = book_element.find_element(:xpath, '//*[@id="book_card_container"]')
+    book_title = container.find_element(:xpath, '//*[@id="book_card_title"]')
+    puts book_title.text
+    array_of_names.push(book_title)
+  end
+  array_of_names
+end

--- a/services/helper.rb
+++ b/services/helper.rb
@@ -56,13 +56,41 @@ def process_slides(slides)
   slides_activos
 end
 
-def get_books_names(book_elements_list)
-  array_of_names = []
-  book_elements_list.each do |book_element|
-    container = book_element.find_element(:xpath, '//*[@id="book_card_container"]')
-    book_title = container.find_element(:xpath, '//*[@id="book_card_title"]')
-    puts book_title.text
-    array_of_names.push(book_title)
+def process_filter(date_filter)
+  filter = {}
+  case date_filter
+  when 'from_date'
+    filter[:xpath] = '//*[@id="search_picker"]/div/div/input'
+    filter[:date] = '01-01-2014'
+  when 'until_date'
+    filter[:xpath] = '//*[@id="date_picker"]/div/div/input'
+    filter[:date] = '12-31-2014'
   end
-  array_of_names
+  filter
+end
+
+def total_amount_of_books
+  book_count = 0
+  next_arrow = $driver.find_element(:xpath, '//*[@id="next_arrow"]')
+  while next_arrow.attribute(:class) != 'unable'
+    book_items = $driver.find_elements(:id, 'book_item')
+    book_count += book_items.length
+    click(:xpath, '//*[@id="next_arrow"]')
+  end
+  book_items = $driver.find_elements(:id, 'book_item')
+  book_count += book_items.length
+  book_count
+end
+
+def apply_filters
+  from_date_xpath = '//*[@id="search_picker"]/div/div/input'
+  until_date_xpath = '//*[@id="date_picker"]/div/div/input'
+  wait_for_element_to_be_ready(:xpath, from_date_xpath)
+  check_element_text(:xpath, '', from_date_xpath, true)
+  click(:xpath, from_date_xpath)
+  enter_text(:xpath, '01-01-2014', from_date_xpath)
+  wait_for_element_to_be_ready(:xpath, until_date_xpath)
+  check_element_text(:xpath, '', until_date_xpath, true)
+  click(:xpath, until_date_xpath)
+  enter_text(:xpath, '12-31-2014', until_date_xpath)
 end


### PR DESCRIPTION
## Summary
- Added `date_filter.feature` file to describe filtering scenarios for wBooks API
    - Replaced the login background with a before hook for every feature with the `@logged` tag
    - Scenarios:
        - Applying both filters to the books list
        - Applying only `from` filter to the book list
        - Applying `from` filter with current date so that every book will be excluded (the latest publication date registered is from 2015)
        - Removing the filters

## Known Issues
- Filters don't work completely right, so there are some scenarios that were excluded:
    - Applying only `until` filter to the book list
    - Applying `until` filter with a date prior to the earliest publication date registered
- There is no way to actually verify the publication date of the resulting list due to the fact that the publication date is not shown on the book card. Therefore, we verify the amount of books resulting and we compare it with the original amount of books from the list without filters.

## Jira Card
https://wolox-support.atlassian.net/browse/QAT-774?atlOrigin=eyJpIjoiYTdjN2NiMjUyNGYxNDNhZjk5ZjdhZGQ0ZWZkMGM1M2YiLCJwIjoiaiJ9